### PR TITLE
Standardize variable names so they are the same across sources

### DIFF
--- a/R/medrxiv-search.R
+++ b/R/medrxiv-search.R
@@ -102,7 +102,8 @@ medrxiv_generic_retrieve_records <- function(search_terms, server = c("biorxiv",
     get_records() %>%
     dplyr::select(doi, date, title) %>%
     # Keep only rows that have "open" in the title.
-    dplyr::filter(stringr::str_detect(title, "[oO]pen"))
+    dplyr::filter(stringr::str_detect(title, "[oO]pen")) |>
+    dplyr::mutate(id = doi, .before = dplyr::everything())
 
   number_articles <- nrow(records_processed)
   cli::cli_inform(c("Records from {.val {server}}",

--- a/R/pubmed-search.R
+++ b/R/pubmed-search.R
@@ -53,13 +53,14 @@ pubmed_extract_relevant_data <- function(record_list) {
   # Set any dates that don't exist to NA.
   date <- if (length(article_date)) article_date else NA
 
-  list(
+  tibble::tibble(
     doi = unlist(metadata$ELocationID),
     date = date,
     title = unlist(metadata$ArticleTitle) %>%
       drop_newlines() %>%
       stringr::str_flatten()
-  )
+  ) |>
+    dplyr::mutate(id = doi, .before = dplyr::everything())
 }
 
 #' Retrieve and process PubMed records from the last five years.

--- a/R/pubmed-search.R
+++ b/R/pubmed-search.R
@@ -73,9 +73,8 @@ pubmed_retrieve_records <- function(search_terms) {
   pubmed_records_processed <- search_terms %>%
     pubmed_get_records() %>%
     purrr::map(pubmed_extract_relevant_data) %>%
-    purrr::keep(~ {
-      is.na(.x$date) | lubridate::ymd(.x$date) >= five_years_ago()
-    })
+    purrr::list_rbind() |>
+    dplyr::filter(is.na(date) | lubridate::ymd(date) >= five_years_ago())
 
   number_articles <- easyPubMed::get_pubmed_ids(search_terms)$Count
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,29 +1,3 @@
-#' Save a list of records to CSV file.
-#'
-#' @param records_list A list to save as CSV.
-#' @param path Path to save the records.
-#'
-#' @return Character for file path, side effect of saving a CSV file.
-#'
-save_list_as_csv <- function(records_list, path) {
-  records_list |>
-    dplyr::bind_rows() |>
-    readr::write_csv(path)
-  return(path)
-}
-
-#' Save a list object to a YAML file.
-#'
-#' @param records_list A list to save as YAML.
-#' @param path Path to save the records.
-#'
-#' @return Character for file path, side effect of saving a YAML file.
-#'
-save_list_as_yaml <- function(records_list, path) {
-  yaml::write_yaml(records_list, path)
-  return(path)
-}
-
 #' Save a tibble to a CSV file.
 #'
 #' @param records_tbl A tibble to save to file.

--- a/R/zenodo-search.R
+++ b/R/zenodo-search.R
@@ -66,7 +66,7 @@ zenodo_extract_relevant_data <- function(record_list) {
     stringr::str_flatten("; ") %>%
     stringr::str_trim()
 
-  list(
+  tibble::tibble(
     # creators = creators,
     doi = record_list$links$doi,
     date = record_list$metadata$publication_date,
@@ -76,7 +76,8 @@ zenodo_extract_relevant_data <- function(record_list) {
     # description = record_list$metadata$description,
     type = record_list$metadata$upload_type,
     keywords = keywords
-  )
+  ) |>
+    dplyr::mutate(id = doi, .before = dplyr::everything())
 }
 
 #' Retrieve records from Zenodo in the last 5 years.

--- a/R/zenodo-search.R
+++ b/R/zenodo-search.R
@@ -98,7 +98,8 @@ zenodo_retrieve_records <- function(search_terms) {
   # Extract necessary data and keep only last five years
   zenodo_records_processed <- zenodo_records %>%
     purrr::map(zenodo_extract_relevant_data) %>%
-    purrr::keep(~ lubridate::ymd(lubridate::as_date(.x$date)) >= five_years_ago())
+    purrr::list_rbind() |>
+    dplyr::filter(lubridate::ymd(date) >= five_years_ago())
 
   # There's less entries from the original
   cli::cli_inform(c("Records from Zenodo",

--- a/R/zenodo-search.R
+++ b/R/zenodo-search.R
@@ -68,7 +68,7 @@ zenodo_extract_relevant_data <- function(record_list) {
 
   tibble::tibble(
     # creators = creators,
-    doi = record_list$links$doi,
+    doi = stringr::str_remove(record_list$links$doi, "^https://doi.org/"),
     date = record_list$metadata$publication_date,
     title = record_list$metadata$title %>%
       drop_newlines() %>%

--- a/_targets.R
+++ b/_targets.R
@@ -47,7 +47,7 @@ list(
   ),
   tar_target(
     name = data_raw_zenodo,
-    command = save_list_as_csv(zenodo_records, here::here("data-raw/zenodo.csv")),
+    command = save_as_csv(zenodo_records, here::here("data-raw/zenodo.csv")),
     format = "file"
   ),
   # PubMed ------------------------------------------------------------------
@@ -61,7 +61,7 @@ list(
   ),
   tar_target(
     name = data_raw_pubmed,
-    command = save_list_as_csv(pubmed_records, here::here("data-raw/pubmed.csv")),
+    command = save_as_csv(pubmed_records, here::here("data-raw/pubmed.csv")),
     format = "file"
   ),
   # arXiv ------------------------------------------------------------------


### PR DESCRIPTION
This was mostly done, except some had `id` and others had `doi`. So now all of them use `id`.